### PR TITLE
Pkg.add explicit url=...

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ```julia
 using Pkg
-Pkg.add("https://github.com/alfredjmduncan/KentFinancialEconomics")
+Pkg.add(url = "https://github.com/alfredjmduncan/KentFinancialEconomics")
 
 ```
 


### PR DESCRIPTION
just a minor detail, julia 1.6 told me to be specific and use url="..."

reference: https://pkgdocs.julialang.org/v1/api/#Pkg.add